### PR TITLE
adding readthedocs configure file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+# for readthedocs
+jinja2<3.1.0
+Markdown<3.2


### PR DESCRIPTION
## Changelog

1. Adding requirements.txt file for creating readthedocs
2. adding configure file for readthedocs.

Reason :

![image](https://user-images.githubusercontent.com/54245038/198196301-1447e93c-0540-4ed5-ad34-e057954ed793.png)

`AttributeError: module 'jinja2' has no attribute 'contextfilter'`